### PR TITLE
Hotfix board regex

### DIFF
--- a/scrum/tools/tests/test_board.py
+++ b/scrum/tools/tests/test_board.py
@@ -87,6 +87,8 @@ def test_extract_cards(trello_api):
     assert cards is not None
     assert len(cards) > 0
     assert isinstance(cards[0], Card)
+    assert len(board.get_retro_past_sprints()) > 0
+    assert len(board.get_unplanned_past_sprints()) > 0
 
 
 def test_calculate_story_points(trello_api):

--- a/scrum/tools/trello/board.py
+++ b/scrum/tools/trello/board.py
@@ -97,9 +97,8 @@ class Board:
                            for list_obj in self.lists}
 
         # Compile regex patterns once to improve performance
-        unplanned_pattern = re.compile(r"unplanned: \*{2}(\d+)", re.IGNORECASE)
-        retro_pattern = re.compile(
-            r"\\\*\\\* (\d+)\\\*\\\* Retro", re.IGNORECASE)
+        unplanned_pattern = re.compile(r"SP Unplanned:\s*(\d+)\(T\)", re.IGNORECASE)
+        retro_pattern = re.compile(r"SP Retro:\s*(\d+)\(T\)", re.IGNORECASE)
 
         for card in self.board_data:
             curr_card_id = card.get("id")


### PR DESCRIPTION
Issue was found following clean up of Sprint summary card where the regex was not pulling in data for unplanned or retro