### PR TITLE
Adjusted sprint math recommendation calculation using new rate-based formula

### DIFF
--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -217,9 +217,15 @@ def main():
     show_sp_calculations(story_points)
     story_points = prompt_for_manual_corrections(story_points)
 
+    # Gather past sprints
+    sprint_summaries = sprint_db_manager.get_sprint_summary_from_db(
+        board_config['board_id']
+    )
+
     # Compute recommendation
-    recommendation = compute_recommendation(
-        board, story_points, sprint_controls)
+    breakdown = compute_recommendation(
+        sprint_summaries, sprint_controls)
+    recommendation = breakdown['recommendation']
 
     # Insert sprint summary data into the database
     insert_sprint_summary(
@@ -296,6 +302,9 @@ def compute_recommendation(sprint_summaries, sprint_controls):
 
     # Calculate per-sprint rates, skipping sprints with no available days
     sprint_rates = []
+    unplanned_remainders = []
+    retro_remainders = []
+
     for sprint in recent:
         available_days = (sprint['length_days'] * sprint['members']) - sprint['vacation_days']
         if available_days <= 0:
@@ -312,6 +321,8 @@ def compute_recommendation(sprint_summaries, sprint_controls):
             "available_days": available_days,
             "rate": rate,
         })
+        unplanned_remainders.append(sprint['unplanned_remaining'])
+        retro_remainders.append(sprint['retro_remaining'])
 
     if not sprint_rates:
         raise ValueError(
@@ -334,13 +345,19 @@ def compute_recommendation(sprint_summaries, sprint_controls):
 
     # Recommendation calculation
     raw_capacity = median_rate * next_available
-    recommendation = max(0, math.ceil(raw_capacity))
+    median_unplanned_remaining = statistics.median(unplanned_remainders)
+    median_retro_remaining = statistics.median(retro_remainders)
+    recommendation = max(0, math.ceil(
+        raw_capacity - median_retro_remaining - median_unplanned_remaining
+    ))
 
     return {
         "recommendation": recommendation,
         "median_rate": median_rate,
         "next_available_member_days": next_available,
         "raw_capacity": raw_capacity,
+        "median_unplanned_remaining": median_unplanned_remaining,
+        "median_retro_remaining": median_retro_remaining,
         "sprint_rates": sprint_rates,
     }
 

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -174,24 +174,32 @@ def show_recommendation_breakdown(breakdown):
         breakdown (dict): The breakdown dict returned by compute_recommendation.
     """
     print("\n=== Recommendation Breakdown ===")
-    print("Historical sprint rates (last 6):")
+    print("Historical SP completion per sprint:")
     for sr in breakdown['sprint_rates']:
         print(
-            f"  Sprint {sr['start_date']}: "
-            f"{sr['total_completed']} pts / {sr['available_days']} member-days "
-            f"= {sr['rate']:.3f} pts/day"
+            f"  {sr['start_date']}: "
+            f"{sr['total_completed']} SP (over {sr['available_days']} member-days)"
         )
-    print(f"Median rate: {breakdown['median_rate']:.3f} pts/member-day")
-    print(f"Next sprint available member-days: {breakdown['next_available_member_days']}")
-    print(
-        f"Raw capacity: {breakdown['median_rate']:.3f} "
-        f"* {breakdown['next_available_member_days']} "
-        f"= {breakdown['raw_capacity']:.2f}"
+    unplanned_history = ", ".join(str(x) for x in breakdown['unplanned_remainders'])
+    retro_history = ", ".join(str(x) for x in breakdown['retro_remainders'])
+    print(f"Unplanned leftover history: {unplanned_history}")
+    print(f"Retro leftover history: {retro_history}")
+    print(f"Next sprint capacity: {breakdown['next_available_member_days']} member-days")
+
+    raw_pre_ceil = (
+        breakdown['raw_capacity']
+        - breakdown['median_unplanned_remaining']
+        - breakdown['median_retro_remaining']
     )
-    print(f"Median unplanned leftover: -{breakdown['median_unplanned_remaining']:.1f}")
-    print(f"Median retro leftover: -{breakdown['median_retro_remaining']:.1f}")
-    print("---------------------------------")
-    print(f"Recommended planned SP: {breakdown['recommendation']}\n")
+    note = " (floored to zero)" if raw_pre_ceil < 0 else ""
+
+    print(
+        f"\nRecommendation = projected SP for next sprint ({breakdown['raw_capacity']:.1f})"
+        f" - median unplanned leftover ({breakdown['median_unplanned_remaining']:.1f})"
+        f" - median retro leftover ({breakdown['median_retro_remaining']:.1f})"
+        f" = {raw_pre_ceil:.1f}"
+    )
+    print(f"Recommended planned SP: {breakdown['recommendation']}{note}\n")
 
 
 def prompt_for_board_insert():
@@ -403,6 +411,8 @@ def compute_recommendation(sprint_summaries, sprint_controls):
         "raw_capacity": raw_capacity,
         "median_unplanned_remaining": median_unplanned_remaining,
         "median_retro_remaining": median_retro_remaining,
+        "unplanned_remainders": unplanned_remainders,
+        "retro_remainders": retro_remainders,
         "sprint_rates": sprint_rates,
     }
 

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -165,6 +165,33 @@ def show_sp_calculations(story_points, recommendation=None):
         )
     print(results)
 
+def show_recommendation_breakdown(breakdown):
+    """
+    Displays the step-by-step breakdown of how the recommendation was computed.
+
+    Args:
+        breakdown (dict): The breakdown dict returned by compute_recommendation.
+    """
+    print("\n=== Recommendation Breakdown ===")
+    print("Historical sprint rates (last 6):")
+    for sr in breakdown['sprint_rates']:
+        print(
+            f"  Sprint {sr['start_date']}: "
+            f"{sr['total_completed']} pts / {sr['available_days']} member-days "
+            f"= {sr['rate']:.3f} pts/day"
+        )
+    print(f"Median rate: {breakdown['median_rate']:.3f} pts/member-day")
+    print(f"Next sprint available member-days: {breakdown['next_available_member_days']}")
+    print(
+        f"Raw capacity: {breakdown['median_rate']:.3f} "
+        f"* {breakdown['next_available_member_days']} "
+        f"= {breakdown['raw_capacity']:.2f}"
+    )
+    print(f"Median unplanned leftover: -{breakdown['median_unplanned_remaining']:.1f}")
+    print(f"Median retro leftover: -{breakdown['median_retro_remaining']:.1f}")
+    print("---------------------------------")
+    print(f"Recommended planned SP: {breakdown['recommendation']}\n")
+
 
 def prompt_for_board_insert():
     """

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -264,6 +264,7 @@ def main():
     # Print final results
     print("\nFINAL RESULTS:")
     show_sp_calculations(story_points, recommendation)
+    show_recommendation_breakdown(breakdown)
 
     # Optionally save board data to database
     if prompt_for_board_insert() == 0:

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -12,6 +12,7 @@ Functions:
     - prompt_for_board_source: Determines the source of the board data.
     - prompt_for_manual_corrections: Allows manual corrections to story points.
     - show_sp_calculations: Displays the calculated story points.
+    - show_recommendation_breakdown: Displays the step-by-step breakdown of the recommendation.
     - prompt_for_board_insert: Determines whether to insert board data into the database.
     - get_board_data: Retrieve board data either from the database or from the live Trello board.
     - compute_recommendation: Compute the recommended number of story points for the next sprint.
@@ -324,6 +325,22 @@ def compute_recommendation(sprint_summaries, sprint_controls):
     """
     Compute the recommended number of story points for the next sprint
     using a rate-based approach sourced from DB.
+
+    Args:
+        sprint_summaries (list[dict]): Sprint summary rows from the DB,
+            ordered by start_date ASC.
+        sprint_controls (dict): Dictionary containing sprint control data
+            with keys: next_sprint_days, members, missed_next_sprint.
+
+    Returns:
+        dict: Breakdown of the recommendation with keys:
+            recommendation, median_rate, next_available_member_days,
+            raw_capacity, median_unplanned_remaining,
+            median_retro_remaining, sprint_rates.
+
+    Raises:
+        ValueError: If no valid sprint data exists or if next sprint
+            PTO exceeds capacity.
     """
     # Use the last 6 sprints
     recent = sprint_summaries[-6:]

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -286,44 +286,63 @@ def get_board_data(sprint_db_manager, trello_api, board_source):
     return board_data
 
 
-def compute_recommendation(board, story_points, sprint_controls):
+def compute_recommendation(sprint_summaries, sprint_controls):
     """
-    Compute the recommended number of story points for the next sprint.
-
-    Args:
-        board (Board): The Board instance containing card data.
-        story_points (dict): Dictionary containing calculated story points.
-        sprint_controls (dict): Dictionary containing sprint control data.
-
-    Returns:
-        int: The recommended number of story points.
+    Compute the recommended number of story points for the next sprint
+    using a rate-based approach sourced from DB.
     """
-    # Calculate average unplanned and retro leftover points from the past six
-    # sprints
-    avg_unplanned = statistics.median(board.get_unplanned_past_sprints()[-6:])
-    avg_retro_leftover = statistics.median(board.get_retro_past_sprints()[-6:])
+    # Use the last 6 sprints
+    recent = sprint_summaries[-6:]
 
-    # Adjustments based on sprint length and team availability
-    length_adjustment = sprint_controls['last_sprint_days'] / \
-        sprint_controls['next_sprint_days']
-    pto_adjustment = (
-        sprint_controls['missed_next_sprint'] -
-        sprint_controls['missed_last_sprint']
-    ) / sprint_controls['members']
-
-    # Calculate the recommendation
-    recommendation = math.ceil(
-        (
-            story_points['planned']['spent']
-            + story_points['unplanned']['spent']
-            + story_points['retro']['spent']
-            - avg_unplanned
-            - avg_retro_leftover
+    # Calculate per-sprint rates, skipping sprints with no available days
+    sprint_rates = []
+    for sprint in recent:
+        available_days = (sprint['length_days'] * sprint['members']) - sprint['vacation_days']
+        if available_days <= 0:
+            continue
+        total_completed = (
+            sprint['planned_completed']
+            + sprint['unplanned_completed']
+            + sprint['retro_completed']
         )
-        / length_adjustment
-        - pto_adjustment
+        rate = total_completed / available_days
+        sprint_rates.append({
+            "start_date": str(sprint['start_date']),
+            "total_completed": total_completed,
+            "available_days": available_days,
+            "rate": rate,
+        })
+
+    if not sprint_rates:
+        raise ValueError(
+            "No valid sprint data found - cannot compute recommendation."
+        )
+
+    # Median rate across historical sprints
+    median_rate = statistics.median([r['rate'] for r in sprint_rates])
+
+    # Next sprint's available member-days
+    next_available = (
+        sprint_controls['next_sprint_days'] * sprint_controls['members']
+        - sprint_controls['missed_next_sprint']
     )
-    return recommendation
+    if next_available <= 0:
+        raise ValueError(
+            f"Next sprint has {next_available} available member-days - "
+            "PTO exceeds capacity. Check sprint control inputs."
+        )
+
+    # Recommendation calculation
+    raw_capacity = median_rate * next_available
+    recommendation = max(0, math.ceil(raw_capacity))
+
+    return {
+        "recommendation": recommendation,
+        "median_rate": median_rate,
+        "next_available_member_days": next_available,
+        "raw_capacity": raw_capacity,
+        "sprint_rates": sprint_rates,
+    }
 
 
 def insert_sprint_summary(sprint_db_manager, board_id,

--- a/scrum/tools/sprint_math.py
+++ b/scrum/tools/sprint_math.py
@@ -194,9 +194,9 @@ def show_recommendation_breakdown(breakdown):
     note = " (floored to zero)" if raw_pre_ceil < 0 else ""
 
     print(
-        f"\nRecommendation = projected SP for next sprint ({breakdown['raw_capacity']:.1f})"
-        f" - median unplanned leftover ({breakdown['median_unplanned_remaining']:.1f})"
-        f" - median retro leftover ({breakdown['median_retro_remaining']:.1f})"
+        f"\nRecommendation = SP capacity ({breakdown['raw_capacity']:.1f})"
+        f" - unplanned LO median ({breakdown['median_unplanned_remaining']:.1f})"
+        f" - retro LO median ({breakdown['median_retro_remaining']:.1f})"
         f" = {raw_pre_ceil:.1f}"
     )
     print(f"Recommended planned SP: {breakdown['recommendation']}{note}\n")

--- a/scrum/tools/tests/test_sprint_math.py
+++ b/scrum/tools/tests/test_sprint_math.py
@@ -1,0 +1,249 @@
+"""
+test_sprint_math.py
+
+Unit tests for the compute_recommendation function in sprint_math.py
+Uses plain dicts to simulate sprint_summary DB rows. No DB or API needed
+
+Test Cases:
+    - test_basic_calculation: Verifies correct output with 6 identical sprints
+    - test_fewer_than_6_sprints: Works with fewer sprints than the 6-sprint lookback
+    - test_leftover_subtraction: Unplanned/retro remaining are subtracted
+    - test_ceiling_applied: Result is always rounded up via math.ceil
+    - test_returns_breakdown_dict: Return value contains all expected keys
+    - test_uses_last_6_only: Only the most recent 6 sprints influence the result
+    - test_all_sprints_zero_available_days: Raises ValueError when no usable data exists
+    - test_pto_exceeds_next_sprint_capacity: Raises ValueError when next sprint has no available days
+    - test_leftovers_exceed_capacity_floors_at_zero: Recommendation floors at 0 when leftovers > raw capacity
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+parent_path = Path(__file__).parent.parent
+sys.path.append(str(parent_path))
+
+from sprint_math import compute_recommendation
+
+
+def make_sprint_summary(
+    start_date="2026-01-01",
+    length_days=10,
+    members=8,
+    vacation_days=0,
+    planned_completed=10,
+    unplanned_completed=3,
+    retro_completed=2,
+    unplanned_remaining=1,
+    retro_remaining=1,
+    **kwargs,
+):
+    """Class to generate a sprint_summary dict with controllable values"""
+    return {
+        "start_date": start_date,
+        "length_days": length_days,
+        "members": members,
+        "vacation_days": vacation_days,
+        "planned_completed": planned_completed,
+        "unplanned_completed": unplanned_completed,
+        "retro_completed": retro_completed,
+        "planned_total": kwargs.get("planned_total", planned_completed),
+        "planned_remaining": kwargs.get("planned_remaining", 0),
+        "unplanned_total": kwargs.get("unplanned_total", unplanned_completed),
+        "unplanned_remaining": unplanned_remaining,
+        "retro_total": kwargs.get("retro_total", retro_completed),
+        "retro_remaining": retro_remaining,
+    }
+
+
+@pytest.fixture
+def default_sprint_controls():
+    return {
+        "next_sprint_days": 10,
+        "members": 8,
+        "missed_next_sprint": 0,
+        "last_sprint_days": 10,
+        "missed_last_sprint": 0,
+    }
+
+
+class TestComputeRecommendation:
+    def test_basic_calculation(self, default_sprint_controls):
+        """6 identical sprints, result should match hand calculation"""
+        # Generate 6 past sprints
+        sprints = [make_sprint_summary() for _ in range(6)]  # 10+3+2=15 pts, 80 days
+
+        # Compute the recommendations
+        result = compute_recommendation(sprints, default_sprint_controls)
+
+        # Check that the results matches expected values
+        # Check rate
+        expected_rate = 15 / 80  # 0.1875
+        # Check raw SP score before subtraction
+        expected_raw = expected_rate * 80  # 15.0
+        # Check recommendation after subtracting leftovers (1 unplanned + 1 retro)
+        expected = math.ceil(expected_raw - 1 - 1)  # 13
+        # Assert the recommendation
+        assert result["recommendation"] == expected
+        # Assert the rates are the same
+        assert result["median_rate"] == pytest.approx(expected_rate)
+
+    def test_fewer_than_6_sprints(self, default_sprint_controls):
+        """3 sprints, should work with whatever is available"""
+        # Only 3 sprints available instead of 6
+        sprints = [make_sprint_summary() for _ in range(3)]
+
+        result = compute_recommendation(sprints, default_sprint_controls)
+
+        # Same math as basic: rate=0.1875, raw=15, minus 1, minus 1 = 13
+        assert result["recommendation"] == 13
+        assert len(result["sprint_rates"]) == 3
+        assert result["median_rate"] == pytest.approx(15 / 80)
+        assert result["next_available_member_days"] == 80
+        assert result["raw_capacity"] == pytest.approx(15.0)
+        assert result["median_unplanned_remaining"] == pytest.approx(1.0)
+        assert result["median_retro_remaining"] == pytest.approx(1.0)
+
+    def test_leftover_subtraction(self, default_sprint_controls):
+        """Nonzero unplanned_remaining and retro_remaining are subtracted"""
+        # Each sprint has 5 unplanned remaining and 3 retro remaining
+        sprints = [
+            make_sprint_summary(unplanned_remaining=5, retro_remaining=3)
+            for _ in range(6)
+        ]
+
+        result = compute_recommendation(sprints, default_sprint_controls)
+
+        # rate=15/80=0.1875, raw=15.0, minus 5 unplanned, minus 3 retro = 7
+        expected = math.ceil(15.0 - 5 - 3)
+        assert result["recommendation"] == expected
+        assert result["median_unplanned_remaining"] == pytest.approx(5.0)
+        assert result["median_retro_remaining"] == pytest.approx(3.0)
+
+    def test_ceiling_applied(self, default_sprint_controls):
+        """Result should be math.ceil'd when calculation is fractional"""
+        # 17 pts / 80 days = 0.2125, but PTO of 3 makes next_available = 77
+        #   This produces a fraction that should be rounded
+        # Copy defaults but override missed_next_sprint to 3
+        controls = {**default_sprint_controls, "missed_next_sprint": 3}
+        sprints = [
+            make_sprint_summary(
+                planned_completed=12, unplanned_completed=3, retro_completed=2,
+                unplanned_remaining=1, retro_remaining=1,
+            )
+            for _ in range(6)
+        ]
+
+        result = compute_recommendation(sprints, controls)
+
+        # rate=17/80=0.2125, raw=0.2125*77=16.3625, minus 1, minus 1 = 14.3625 -> 15
+        expected_raw = (17 / 80) * 77
+        expected = math.ceil(expected_raw - 1 - 1)
+        assert result["recommendation"] == expected
+        assert result["recommendation"] == 15
+        assert result["median_rate"] == pytest.approx(17 / 80)
+        assert result["next_available_member_days"] == 77
+        assert result["raw_capacity"] == pytest.approx(expected_raw)
+        assert result["median_unplanned_remaining"] == pytest.approx(1.0)
+        assert result["median_retro_remaining"] == pytest.approx(1.0)
+
+    def test_returns_breakdown_dict(self, default_sprint_controls):
+        """Return value is a dict with all expected keys"""
+        sprints = [make_sprint_summary() for _ in range(6)]
+
+        result = compute_recommendation(sprints, default_sprint_controls)
+
+        expected_keys = {
+            "recommendation",
+            "median_rate",
+            "next_available_member_days",
+            "raw_capacity",
+            "median_unplanned_remaining",
+            "median_retro_remaining",
+            "sprint_rates",
+        }
+        assert set(result.keys()) == expected_keys
+        assert isinstance(result["sprint_rates"], list)
+        assert len(result["sprint_rates"]) == 6
+
+    def test_uses_last_6_only(self, default_sprint_controls):
+        """When more than 6 sprints are passed, only the last 6 are used"""
+        # First 4 sprints have a very different rate (0.5) than last 6 (0.1875)
+        old_sprints = [
+            make_sprint_summary(planned_completed=30, unplanned_completed=6, retro_completed=4,
+                                unplanned_remaining=0, retro_remaining=0)
+            for _ in range(4)
+        ]
+        recent_sprints = [
+            make_sprint_summary(unplanned_remaining=0, retro_remaining=0)
+            for _ in range(6)
+        ]
+        all_sprints = old_sprints + recent_sprints
+
+        result = compute_recommendation(all_sprints, default_sprint_controls)
+
+        # Should use the recent rate (0.1875), not be influenced by old (0.5)
+        assert result["median_rate"] == pytest.approx(15 / 80)
+        assert len(result["sprint_rates"]) == 6
+        assert result["next_available_member_days"] == 80
+        assert result["raw_capacity"] == pytest.approx(15.0)
+        assert result["median_unplanned_remaining"] == pytest.approx(0.0)
+        assert result["median_retro_remaining"] == pytest.approx(0.0)
+
+    def test_skips_sprints_with_zero_available_days(self, default_sprint_controls):
+        """Sprints where available_member_days <= 0 should be skipped"""
+        # One bad sprint with vacation_days == capacity (80 - 80 = 0 available days)
+        bad_sprint = make_sprint_summary(vacation_days=80)
+        good_sprints = [
+            make_sprint_summary(unplanned_remaining=0, retro_remaining=0)
+            for _ in range(6)
+        ]
+        all_sprints = [bad_sprint] + good_sprints
+
+        result = compute_recommendation(all_sprints, default_sprint_controls)
+
+        # Bad sprint skipped, only the 6 good ones used
+        assert result["median_rate"] == pytest.approx(15 / 80)
+        assert len(result["sprint_rates"]) == 6
+        assert result["next_available_member_days"] == 80
+        assert result["raw_capacity"] == pytest.approx(15.0)
+        assert result["median_unplanned_remaining"] == pytest.approx(0.0)
+        assert result["median_retro_remaining"] == pytest.approx(0.0)
+
+    def test_all_sprints_zero_available_days(self, default_sprint_controls):
+        """All sprints have zero available days, should raise ValueError"""
+        # Every sprint has vacation_days == capacity
+        sprints = [make_sprint_summary(vacation_days=80) for _ in range(3)]
+
+        with pytest.raises(ValueError, match="No valid sprint data found"):
+            compute_recommendation(sprints, default_sprint_controls)
+
+    def test_pto_exceeds_next_sprint_capacity(self, default_sprint_controls):
+        """PTO exceeds next sprint member-days, should raise ValueError"""
+        # Copy defaults but override missed_next_sprint to 100 (exceeds capacity of 10*8 = 80)
+        controls = {**default_sprint_controls, "missed_next_sprint": 100}
+        sprints = [make_sprint_summary() for _ in range(6)]
+
+        with pytest.raises(ValueError, match="available member-days"):
+            compute_recommendation(sprints, controls)
+
+    def test_leftovers_exceed_capacity_floors_at_zero(self, default_sprint_controls):
+        """When median leftovers exceed raw capacity, recommendation floors at 0"""
+        # Very low completion rate (2/80 = 0.025, raw = 2.0) but huge leftovers (5+5 = 10)
+        #   raw - leftovers = 2.0 - 10 = -8, should floor to 0
+        sprints = [
+            make_sprint_summary(
+                planned_completed=1, unplanned_completed=1, retro_completed=0,
+                unplanned_remaining=5, retro_remaining=5,
+            )
+            for _ in range(6)
+        ]
+
+        result = compute_recommendation(sprints, default_sprint_controls)
+
+        assert result["recommendation"] == 0
+        assert result["raw_capacity"] == pytest.approx(2.0)
+        assert result["median_unplanned_remaining"] == pytest.approx(5.0)
+        assert result["median_retro_remaining"] == pytest.approx(5.0)

--- a/scrum/tools/tests/test_sprint_math.py
+++ b/scrum/tools/tests/test_sprint_math.py
@@ -40,7 +40,7 @@ def make_sprint_summary(
     retro_remaining=1,
     **kwargs,
 ):
-    """Class to generate a sprint_summary dict with controllable values"""
+    """Generate a sprint_summary dict with controllable values"""
     return {
         "start_date": start_date,
         "length_days": length_days,

--- a/scrum/tools/tests/test_sprint_math.py
+++ b/scrum/tools/tests/test_sprint_math.py
@@ -162,6 +162,8 @@ class TestComputeRecommendation:
             "raw_capacity",
             "median_unplanned_remaining",
             "median_retro_remaining",
+            "unplanned_remainders",
+            "retro_remainders",
             "sprint_rates",
         }
         assert set(result.keys()) == expected_keys

--- a/scrum/tools/trello/db.py
+++ b/scrum/tools/trello/db.py
@@ -151,7 +151,7 @@ class SprintDBManager:
 
         try:
             select_statement = """
-                SELECT * FROM sprint_summary WHERE board_id = %s ORDER BY created_at ASC;
+                SELECT * FROM sprint_summary WHERE board_id = %s ORDER BY start_date ASC;
             """
             cursor.execute(select_statement, (board_id,))
 


### PR DESCRIPTION
Rewrote `compute_recommendation` to use a rate-based formula sourced from historical sprint summary DB entries. The new approach computes per-sprint completion rates (points / available member-days) across the last 6 sprints, takes the median, and adjusts for next sprint capacity and historical leftover work. Also added `show_recommendation_breakdown` to print the step-by-step calculation after final results, fixed the sprint summary query to order by `start_date` instead of `created_at`, and added a test file covering calculation, edge cases, and errors